### PR TITLE
Add support for REST API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.autogit

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 === Wordpress Hide Posts ===
-Contributors: martin7ba
+Contributors: martin7ba,conschneider
 Tags: hide posts, hide, show, visibility, filter, woocommerce, hide products, rss feed
 Requires at least: 4.0
 Tested up to: 5.4
 Requires PHP: 5.6
-Stable tag: 0.4.2
+Stable tag: 0.4.3
 License: GPLv3 or later
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
- 
+
 This plugin allows you to hide any posts on the home page, category page, search page, tags page, authors page and RSS Feed
 Also you can hide Woocommerce products from Shop page as well as from Product category pages.
 
@@ -16,12 +16,18 @@ To enable it for Woocommerce products or any other Custom Post type go to Settin
 When you create new or edit post, you can choose on which archive page to hide that post as well as on the home page.
 
 == Installation ==
- 
+
 1. Upload the `whp-hide-posts` folder to the `/wp-content/plugins/` directory
 2. Activate the plugin through the 'Plugins' menu in WordPress
 3. Enable Hide post functionality for additional post types by going to Settings -> Hide Posts
 
 == Changelog ==
+
+= 0.4.3 =
+*Release Date - 06 April 2020*
+
+* Added option to hide posts from REST API all posts query: /wp-json/wp/v2/posts/
+Note: Single post entry in REST API remains available /wp-json/wp/v2/posts/[post_id]
 
 = 0.4.2 =
 *Release Date - 13 February 2020*

--- a/classes/WHP_Post_Hide.php
+++ b/classes/WHP_Post_Hide.php
@@ -55,7 +55,6 @@ class WHP_Post_Hide {
 				$query->set( 'meta_key', '_whp_hide_on_blog_page' );
 				$query->set( 'meta_compare', 'NOT EXISTS' );
 			}
-
 			// Hide on Categories.
 			if ( is_category() ) {
 				$query->set( 'meta_key', '_whp_hide_on_categories' );
@@ -83,6 +82,11 @@ class WHP_Post_Hide {
 			// Hide in RSS Feed.
 			if ( is_feed() ) {
 				$query->set( 'meta_key', '_whp_hide_in_rss_feed' );
+				$query->set( 'meta_compare', 'NOT EXISTS' );
+			}
+			// Hide in REST API
+			if (( defined( 'REST_REQUEST' ) && REST_REQUEST )) {
+				$query->set( 'meta_key', '_whp_hide_in_rest_api' );
 				$query->set( 'meta_compare', 'NOT EXISTS' );
 			}
 

--- a/classes/admin/WHP_Post_Hide_Metabox.php
+++ b/classes/admin/WHP_Post_Hide_Metabox.php
@@ -106,6 +106,7 @@ class WHP_Post_Hide_Metabox {
 		$whp_data['_whp_hide_on_tags'] = ! empty( $_POST['whp_hide_on_tags'] ) ? true : false;
 		$whp_data['_whp_hide_on_authors'] = ! empty( $_POST['whp_hide_on_authors'] ) ? true : false;
 		$whp_data['_whp_hide_in_rss_feed'] = ! empty( $_POST['whp_hide_in_rss_feed'] ) ? true : false;
+		$whp_data['_whp_hide_in_rest_api'] = ! empty( $_POST['whp_hide_in_rest_api'] ) ? true : false;
 		$whp_data['_whp_hide_on_blog_page'] = ! empty( $_POST['whp_hide_on_blog_page'] ) ? true : false;
 
 		if ( whp_wc_exists() && whp_admin_wc_product() ) {

--- a/classes/admin/WHP_Post_Hide_Metabox.php
+++ b/classes/admin/WHP_Post_Hide_Metabox.php
@@ -57,6 +57,7 @@ class WHP_Post_Hide_Metabox {
 		$whp_hide_on_tags  = get_post_meta( $post->ID, "_whp_hide_on_tags", true );
 		$whp_hide_on_authors  = get_post_meta( $post->ID, "_whp_hide_on_authors", true );
 		$whp_hide_in_rss_feed  = get_post_meta( $post->ID, "_whp_hide_in_rss_feed", true );
+		$whp_hide_in_rss_REST_API  = get_post_meta( $post->ID, "_whp_hide_in_rest_api", true );
 		$whp_hide_on_blog_page  = get_post_meta( $post->ID, "_whp_hide_on_blog_page", true );
 
 		if ( whp_wc_exists() && whp_admin_wc_product() ) {

--- a/views/admin/template-admin-post-metabox.php
+++ b/views/admin/template-admin-post-metabox.php
@@ -46,7 +46,7 @@ global $post;
 	<p>
 		<label for='whp_hide_in_rest_api'>
 			<input type='checkbox' name="whp_hide_in_rest_api" value='1' <?php //checked( $whp_hide_in_rest_api, 1 ); ?> id='whp_hide_in_rest_api'>
-			<?php //_e( 'Hide in REST API', 'whp' ); ?>
+			<?php _e( 'Hide in REST API', 'whp' ); ?>
 		</label>
 	</p>
 	<p>

--- a/views/admin/template-admin-post-metabox.php
+++ b/views/admin/template-admin-post-metabox.php
@@ -44,6 +44,12 @@ global $post;
 		</label>
 	</p>
 	<p>
+		<label for='whp_hide_in_rest_api'>
+			<input type='checkbox' name="whp_hide_in_rest_api" value='1' <?php //checked( $whp_hide_in_rest_api, 1 ); ?> id='whp_hide_in_rest_api'>
+			<?php //_e( 'Hide in REST API', 'whp' ); ?>
+		</label>
+	</p>
+	<p>
 		<label for='whp_hide_on_blog_page'>
 			<input type='checkbox' name="whp_hide_on_blog_page" value='1' <?php checked( $whp_hide_on_blog_page, 1 ); ?> id='whp_hide_on_blog_page'>
 			<?php _e( 'Hide on blog page', 'whp' ); ?>


### PR DESCRIPTION
Added option to hide posts from REST API all posts endpoint: `/wp-json/wp/v2/posts/`

To test: 

* Navigate to post
* Toggle:  Hide Posts >> Hide in REST API option. 
* Observe post vanishes from `/wp-json/wp/v2/posts/`
* Note: Single post entry in REST API remains available `/wp-json/wp/v2/posts/[post_id]`

Let me know any required code changes and if you want me to write a changelog entry as well. I skipped that for now, but that is no problem. 

Kind regards, 
